### PR TITLE
Feature: add support for rendering manual test cases

### DIFF
--- a/src/script/render_json_test_result.py
+++ b/src/script/render_json_test_result.py
@@ -69,14 +69,20 @@ class Testresult:
         except (KeyError):
             pass
 
+        # default method is 'Automatic'
+        method = 'Automatic'
+        for feature_tag in features_tags:
+            if 'manual' in feature_tag.split(' '):
+                method = 'Manual'
+
         # Create rendering
         return f'''            <tr>
                 <th scope="row">{self.count}</th>
                 <td>{self.name}</td>
-                <td>Automatic</td>
-                <td>Pipeline</td>
+                <td>{method}</td>
+                <td>{'Pipeline' if method == 'Automatic' else 'Not Applicable'}</td>
                 <td>{time_executed}</td>
-                <td class="{self.status}">{self.status}</td>
+                <td class="{self.status if method != 'Manual' else 'na'}">{'Not Applicable' if method == 'Manual' else self.status}</td>
                 <td>{'<kbd>' + '</kbd><kbd>'.join(features_tags) + '</kbd>' if features_tags else ''.join(na_tag)}</td>
             </tr>'''
 

--- a/src/template/VerificationReportTemplate.html
+++ b/src/template/VerificationReportTemplate.html
@@ -84,7 +84,9 @@
         }
         .na {
             background-color: #e1e8ebb3;
-        }    </style>
+        }    
+        
+    </style>
 </head>
 
 <body>

--- a/src/template/VerificationReportTemplate.html
+++ b/src/template/VerificationReportTemplate.html
@@ -77,12 +77,14 @@
             background-color: #81c784;
         }
         .broken {
-            background-color: #e57373;
+            background-color: #ffdd00;
         }
         .failed {
             background-color: #e57373;
         }
-    </style>
+        .na {
+            background-color: #e1e8ebb3;
+        }    </style>
 </head>
 
 <body>


### PR DESCRIPTION
This PR introduces some enhancements related to the rendering of the verification report:
* Features tagged with `@manual` now show up in the report's 'Method' column as 'Manual' instead of 'Automatic'
* Features tagged with `@manual` now show up in the report's 'Executed by' column as 'Not Applicable' instead of 'Pipeline'
* Features tagged with `@manual` now show up in the report's 'Conclusion' column as 'Not Applicable' and the background is grey instead of red
* Features whose test cases are 'broken' or not implemented have a yellow background instead of red which is reserved for actual 'failed' tests

Should you have any questions please let me know.